### PR TITLE
Update NBL announcer name to Muffit

### DIFF
--- a/trackers/Anthelion.tracker
+++ b/trackers/Anthelion.tracker
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<!-- ***** BEGIN LICENSE BLOCK *****
+   Version: MPL 1.1
+
+   The contents of this file are subject to the Mozilla Public License Version
+   1.1 (the "License"); you may not use this file except in compliance with
+   the License. You may obtain a copy of the License at
+   http://www.mozilla.org/MPL/
+
+   Software distributed under the License is distributed on an "AS IS" basis,
+   WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+   for the specific language governing rights and limitations under the
+   License.
+   The Original Code is IRC Auto Downloader.
+   The Initial Developer of the Original Code is
+   David Nilsson.
+   Portions created by the Initial Developer are Copyright (C) 2010, 2011
+   the Initial Developer. All Rights Reserved.
+
+   Contributor(s):
+   kzmgd
+
+   ***** END LICENSE BLOCK ***** -->
+
+<trackerinfo
+  type="ant"
+	shortName="ant"
+	longName="Anthelion"
+	siteName="Anthelion.me">
+
+	<settings>
+		<gazelle_description/>
+		<gazelle_authkey/>
+		<gazelle_torrent_pass/>
+	</settings>
+
+	<servers>
+		<server
+			network="Anthelion"
+			serverNames="irc.nebulance.cc"
+			channelNames="#ant-announce"
+			announcerNames="Sauron"
+			/>
+	</servers>
+
+	<parseinfo>
+		<linepatterns>
+			<extract>
+				<!--[Feature Film] The Thing from Another World (1951) [H264 / MKV / 1080p / DTS / Subs / Freeleech!] [8.38 GB - Uploader: somebody] / https://anthelion.me/torrents.php?action=download&id=3412 - horror,sci.fi -->
+				<regex value="\[(.*?)\] (.*?) \((\d{4})\) \[(.*?)\] \[(.*) - Uploader: (.*?)\] (https?:\/\/\S*) - (\S*)"/>
+				<vars>
+					<var name="category"/>
+					<var name="torrentName"/>
+					<var name="year"/>
+					<var name="$releaseTags"/>
+					<var name="$torrentSize"/>
+					<var name="uploader"/>
+					<var name="$downloadUrl"/>
+					<var name="tags"/>
+				</vars>
+			</extract>
+		</linepatterns>
+		<linematched>
+
+			<extracttags srcvar="$releaseTags" split="/">
+				<setvarif varName="resolution" regex="^(?:SD|Standard?Def.*|480i|480p|576p|720p|810p|1080p|1080i|2160p|PD|Portable Device)$"/>
+				<setvarif varName="source" regex="^(?:R5|DVDScr|BRRip|CAM|TS|TELESYNC|TC|TELECINE|DSR|PDTV|HDTV|DVDRip|BDRip|DVDR|DVD|BluRay|Blu\-Ray|WEBRip|WEB\-DL|WebDL|WEB|TVRip|HDDVD|HD\-DVD)$"/>
+				<setvarif varName="encoder" regex="^(?:XviD|DivX|x264|x264\-Hi10p|h\.264|h264|mpeg2|VC\-1|VC1|WMV|Remux)$"/>
+				<setvarif varName="container" regex="^(?:AVI|MKV|VOB|MPEG|MP4|ISO|WMV|TS|M4V|M2TS)$"/>
+				<setvarif varName="scene" regex="^Scene$" newValue="true" />
+				<setvarif varName="format" regex="^(?:MP3|FLAC|Ogg|AAC|AC3|DTS|Video HD|PCM|DVD9|DVD5|Vorbis|True\-HD)$"/>
+				<setvarif varName="freeleech" regex="^Freeleech\!$" newValue="true" />
+			</extracttags>
+
+			<var name="torrentUrl">
+				<var name="$downloadUrl"/>
+				<string value="&amp;authkey="/>
+				<var name="authkey"/>
+				<string value="&amp;torrent_pass="/>
+				<var name="torrent_pass"/>
+			</var>
+			<extract srcvar="torrentName">
+				<regex value="(.*)"/>
+				<vars>
+					<var name="name1"/>
+				</vars>
+			</extract>
+		</linematched>
+		<ignore>
+		</ignore>
+	</parseinfo>
+</trackerinfo>

--- a/trackers/Nebulance.tracker
+++ b/trackers/Nebulance.tracker
@@ -42,7 +42,7 @@
 			network="Nebulance"
 			serverNames="irc.nebulance.cc"
 			channelNames="#nbl-announce"
-			announcerNames="DRADIS"
+			announcerNames="Muffit"
 			/>
 	</servers>
 

--- a/trackers/Nebulance.tracker
+++ b/trackers/Nebulance.tracker
@@ -21,6 +21,7 @@
    ^tammy^
    MrRandom
    Alastor
+	 kzmgd
 
    ***** END LICENSE BLOCK ***** -->
 
@@ -48,9 +49,9 @@
 	<parseinfo>
 		<linepatterns>
 			<extract>
-				<!--[Episodes] The Vet Life - S02E08 [WebRip / x264 / MKV / 720p / HD / VLAD / The.Vet.Life.S02E08.Tuskegee.Reunion.720p.ANPL.WEBRip.AAC2.0.x264-VLAD.mkv] [702.00 MB - Uploader: Zoe] - http://nebulance.io/torrents.php?id=147-->
-				<!--[Seasons] Police Interceptors - S10 [HDTV / x264 / MKV / MP4 / 480p / SD / BTN / Police.Interceptors.S10.HDTV.x264-BTN] [5.27 GB - Uploader: partwish031] - http://nebulance.io/torrents.php?id=1472-->
-				<regex value="\[(.*?)\] (.*?) \[(.*?)\] \[(.*?) - Uploader: (.*?)\] - (https?://.*)id=(\d+)"/>
+				<!--[Episodes] The Vet Life - S02E08 [WebRip / x264 / MKV / 720p / HD / VLAD / The.Vet.Life.S02E08.Tuskegee.Reunion.720p.ANPL.WEBRip.AAC2.0.x264-VLAD.mkv] [702.00 MB - Uploader: Zoe] - http://nebulance.io/torrents.php?id=147 [Tags: comedy,subtitles,cbs] -->
+				<!--[Seasons] Police Interceptors - S10 [HDTV / x264 / MKV / MP4 / 480p / SD / BTN / Police.Interceptors.S10.HDTV.x264-BTN] [5.27 GB - Uploader: partwish031] - http://nebulance.io/torrents.php?id=1472 [Tags: comedy,subtitles,cbs]-->
+				<regex value="\[(.*?)\] (.*?) \[(.*?)\] \[(.*?) - Uploader: (.*?)\] - (https?://.*)id=(\d+) \[Tags: (.*)\]"/>
 				<vars>
 					<var name="category"/>
 					<var name="torrentName"/>
@@ -59,6 +60,7 @@
 					<var name="uploader"/>
 					<var name="$baseUrl"/>
 					<var name="$torrentId"/>
+					<var name="tags"/>
 				</vars>
 			</extract>
 		</linepatterns>


### PR DESCRIPTION
Title says it all; we're merging bots, so the announcer is no longer DRADIS but Muffit.

(I'm happy to re-fork, too, if you want to skip my old community commits)